### PR TITLE
:recycle: main에 접속안되는 현상 해결

### DIFF
--- a/src/main/java/com/t2m/g2nee/front/aop/MemberAspect.java
+++ b/src/main/java/com/t2m/g2nee/front/aop/MemberAspect.java
@@ -1,6 +1,7 @@
 package com.t2m.g2nee.front.aop;
 
 import static com.t2m.g2nee.front.token.util.JwtUtil.SESSION_ID;
+import static com.t2m.g2nee.front.utils.CookieUtil.findCookie;
 
 import com.t2m.g2nee.front.member.dto.response.MemberDetailInfoResponseDto;
 import java.util.Arrays;
@@ -38,10 +39,7 @@ public class MemberAspect {
                 (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
         HttpServletRequest request = servletRequestAttributes.getRequest();
 
-        Cookie c = Arrays.stream(request.getCookies())
-                .filter(cookie -> cookie.getName().equals(SESSION_ID))
-                .findAny()
-                .orElse(null);
+        Cookie c = findCookie(SESSION_ID);
 
         if (c != null) {
             String sessionId = c.getValue();


### PR DESCRIPTION
## #️⃣Related Issue
가끔 main에 접속안되는 현상이 있었습니다. 
로그인, 회원가입 페이지는 되는데 메인만 안들어가지는 현상 수정하였습니다.\


## 📝Work Detail

### 문제상황

![image](https://github.com/nhnacademy-be5-t2m/g2nee-front/assets/68415975/bbf28bfc-98e6-43cc-89d0-bef964d2a810)

- 사진을 보면 NullPointException이 발생합니다.
- main페이지를 들어가게 되면 여러 filter를 거치다가 /books 컨트롤러를 호출합니다.
- /books 컨트롤러에 `@Member` 어노테이션에 따라 
```java
@Around("member()")
    private Object getMemberId(ProceedingJoinPoint joinPoint) throws Throwable {

        Object[] args = joinPoint.getArgs();

        ServletRequestAttributes servletRequestAttributes =
                (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
        HttpServletRequest request = servletRequestAttributes.getRequest();

        Cookie c = Arrays.stream(request.getCookies())
                .filter(cookie -> cookie.getName().equals(SESSION_ID))
                .findAny()
                .orElse(null);

        if (c != null) {
            String sessionId = c.getValue();
            Long memberId = getMemberId(sessionId);
            threadLocal.set(memberId);
        }
        Object result = joinPoint.proceed(args);
        threadLocal.remove();
        return result;
    }
```

이 부분이 작동하게 되는데 여기서 NullPointException이 발생하는 문제였습니다.

```java
        Cookie c = Arrays.stream(request.getCookies())
                .filter(cookie -> cookie.getName().equals(SESSION_ID))
                .findAny()
                .orElse(null);
```
- 이 부분이 오류 부분이었는데 cookie의 값들을 array로 받아 돌면서 SESSION_ID("auth-session") 이라는 이름의 cookie를 찾는 코드입니다. 
- 하지만 처음 main페이지에 접속하게 되면 아무 cookie가 없기 때문에 array가 null이 되어 발생하는 문제였습니다.


---
### 해결방법
- 아래 코드를 사용하여 해결하였습니다.
```java
    public static Cookie findCookie(String cookieName) {
        ServletRequestAttributes servletRequestAttributes =
                (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
        HttpServletRequest request = servletRequestAttributes.getRequest();

        if (Objects.isNull(request.getCookies())) {
            return null;
        }

        return Arrays.stream(request.getCookies())
                .filter(cookie -> cookie.getName().equals(cookieName))
                .findAny()
                .orElse(null);
    }
```
우선 cookie값들이 있는지 확인하고 하나라도 있을 시 array를 통해 cookie를 찾습니다.

---
### 결론
- cookie값이 하나라도 있으면 작동하는 것이고 하나도 없을때 작동하지 않아 main에 접속이 될때도 있고 안될때도 있는 것이었습니다.
- CookieUtil 클래스에 `findCookie(Stiring cookieName)` 메소드가 있으니 추후에 cookie를 찾아야하는 부분에 사용하시면 될 것 같습니다.