### PR TITLE
Token검증개선

### DIFF
--- a/src/main/java/com/t2m/g2nee/front/advice/CustomExceptionAdvice.java
+++ b/src/main/java/com/t2m/g2nee/front/advice/CustomExceptionAdvice.java
@@ -4,6 +4,7 @@ import static com.t2m.g2nee.front.aop.MemberAspect.MEMBER_INFO;
 import static com.t2m.g2nee.front.token.util.JwtUtil.SESSION_ID;
 import static com.t2m.g2nee.front.utils.CookieUtil.deleteCookie;
 
+import com.t2m.g2nee.front.annotation.Member;
 import com.t2m.g2nee.front.aop.MemberAspect;
 import com.t2m.g2nee.front.exception.CustomException;
 import com.t2m.g2nee.front.member.dto.response.MemberDetailInfoResponseDto;
@@ -106,6 +107,7 @@ public class CustomExceptionAdvice {
      * @return
      */
     @ExceptionHandler(HttpClientErrorException.class)
+    @Member
     public String invalidToken(Model model) {
         model.addAttribute("tokenError", "로그인 유효시간이 지났습니다. 재로그인 해주세요.");
         ServletRequestAttributes servletRequestAttributes =

--- a/src/main/java/com/t2m/g2nee/front/payment/controller/PaymentController.java
+++ b/src/main/java/com/t2m/g2nee/front/payment/controller/PaymentController.java
@@ -1,6 +1,7 @@
 package com.t2m.g2nee.front.payment.controller;
 
 import static com.t2m.g2nee.front.aop.MemberAspect.MEMBER_INFO;
+import static com.t2m.g2nee.front.utils.CookieUtil.deleteCookie;
 
 import com.t2m.g2nee.front.annotation.Member;
 import com.t2m.g2nee.front.aop.MemberAspect;
@@ -72,6 +73,7 @@ public class PaymentController {
             memberId = member.getMemberId().toString();
         }
         shoppingCartService.deleteCart(memberId, httpServletResponse);
+        deleteCookie(httpServletResponse, "cart");
         return "payment/paymentSuccess";
     }
 
@@ -88,6 +90,7 @@ public class PaymentController {
             memberId = member.getMemberId().toString();
         }
         shoppingCartService.deleteCart(memberId, httpServletResponse);
+        deleteCookie(httpServletResponse, "cart");
         return "payment/pointPaySuccess";
     }
 

--- a/src/main/java/com/t2m/g2nee/front/utils/HttpHeadersUtil.java
+++ b/src/main/java/com/t2m/g2nee/front/utils/HttpHeadersUtil.java
@@ -22,9 +22,11 @@ public class HttpHeadersUtil {
         httpHeaders.setContentType(MediaType.APPLICATION_JSON);
         httpHeaders.setAccept(List.of(MediaType.APPLICATION_JSON));
 
-        Cookie accessToken = CookieUtil.findCookie(JwtUtil.ACCESS_COOKIE);
-        if (Objects.nonNull(accessToken)) {
-            httpHeaders.add("Authorization", JwtUtil.TOKEN_TYPE + accessToken.getValue());
+        Cookie accessTokenCookie = CookieUtil.findCookie(JwtUtil.ACCESS_COOKIE);
+        if (Objects.nonNull(accessTokenCookie)) {
+            int lastDotIndex = accessTokenCookie.getValue().lastIndexOf('.');
+            String accessToken = accessTokenCookie.getValue().substring(0, lastDotIndex);
+            httpHeaders.add("Authorization", JwtUtil.TOKEN_TYPE + accessToken);
         }
         return httpHeaders;
     }


### PR DESCRIPTION
## #️⃣Related Issue

- token 검증을 개선해보았습니다.
- auth server에서 token을 발급할때 최근 발급된 accessToken도 함께 redis에 저장합니다.
- token을 reIssue하였을때 redis에 제일 최근에 발급된 accessToken과 일치하는지 확인합니다.
- accessToken이 탈취당하여 해커가 다른 accessToken으로 사용하고 있을때 사용자가 사용하던 accessToken을 사용해 재발급을 요청하고 최근 발급된 accessToken과 비교해 다르다면 refreshToken이 삭제되 해커가 더이상 사용할 수 없습니다. 