### PR TITLE
:bug: 사진리뷰작성 enum 추가

### DIFF
--- a/src/main/java/com/t2m/g2nee/front/point/dto/ChangeReason.java
+++ b/src/main/java/com/t2m/g2nee/front/point/dto/ChangeReason.java
@@ -1,7 +1,7 @@
 package com.t2m.g2nee.front.point.dto;
 
 public enum ChangeReason {
-    REVIEW("리뷰작성 적립"), SIGNUP("회원가입 적립"), PURCHASE("구매 적립"), RETIRE("구매 적립금 회수(반품)"), RETURN("사용 포인트 반환(반품)"),
+    PHOTO_REVIEW("사진리뷰작성 적립"),REVIEW("리뷰작성 적립"), SIGNUP("회원가입 적립"), PURCHASE("구매 적립"), RETIRE("구매 적립금 회수(반품)"), RETURN("사용 포인트 반환(반품)"),
     USE("포인트 사용");
 
     private final String name;


### PR DESCRIPTION
## #️⃣Related Issue

> 포인트

## 📝Work Detail

> 포인트적립내역 조회 시 사진리뷰 작성 enum이 없어서 조회를 못하던 현상을 수
